### PR TITLE
Fix point spending rules

### DIFF
--- a/src/components/points-buy/points-buy.tsx
+++ b/src/components/points-buy/points-buy.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react'
-import type { Ability, OnStatChange, Stats,  } from './types'
+import type { Ability, OnStatChange, Stats } from './types'
 
 const abilities: Ability[] = ['STR', 'DEX', 'CON', 'INT', 'WIS', 'CHA']
 const baseStat = 9
@@ -17,23 +17,61 @@ export function PointsBuy() {
     CHA: baseStat,
     left: maxPoints,
   })
+
+  const [inputs, setInputs] = useState<Record<Ability, string>>({
+    STR: String(baseStat),
+    DEX: String(baseStat),
+    CON: String(baseStat),
+    INT: String(baseStat),
+    WIS: String(baseStat),
+    CHA: String(baseStat),
+  })
   
-  const handleStatChange = useCallback<OnStatChange>((stat) => ({ target: { value }}) => {
-    const newValue = Math.floor(Number(value))
-    const multiplier = newValue > 15 ? 2 : 1
+  const costFor = useCallback((val: number) => {
+    const base = Math.max(0, Math.min(val, 14) - 8)
+    const premium = Math.max(0, val - 14) * 2
+    return base + premium
+  }, [])
+
+  const commitStat = useCallback((stat: Ability, raw: number) => {
+    const newValue = Math.max(minStat, Math.min(maxStat, raw))
 
     setStats((prev) => {
-      const remaining = prev.left - ((newValue - prev[stat]) * multiplier)
+      const remaining = prev.left - (costFor(newValue) - costFor(prev[stat]))
 
-      if (remaining < 0) return prev
+      if (remaining < 0) {
+        setInputs((curr) => ({ ...curr, [stat]: String(prev[stat]) }))
+        return prev
+      }
 
+      setInputs((curr) => ({ ...curr, [stat]: String(newValue) }))
       return {
         ...prev,
         [stat]: newValue,
         left: remaining,
       }
     })
-  }, [])
+  }, [costFor])
+
+  const handleStatChange = useCallback<OnStatChange>((stat) => ({ target: { value }}) => {
+    setInputs((curr) => ({ ...curr, [stat]: value }))
+
+    const numeric = Math.floor(Number(value))
+    if (Number.isNaN(numeric)) return
+
+    if (Math.abs(numeric - stats[stat]) === 1) {
+      commitStat(stat, numeric)
+    }
+  }, [commitStat, stats])
+
+  const handleStatBlur = useCallback((stat: Ability) => () => {
+    const numeric = Math.floor(Number(inputs[stat]))
+    if (Number.isNaN(numeric)) {
+      setInputs((curr) => ({ ...curr, [stat]: String(stats[stat]) }))
+      return
+    }
+    commitStat(stat, numeric)
+  }, [commitStat, inputs, stats])
 
   return (
     <div className="mb-32 grid text-center lg:max-w-5xl lg:w-full lg:mb-0 lg:grid-cols-6 lg:text-left">
@@ -44,11 +82,12 @@ export function PointsBuy() {
           <input
             type="number"
             className="w-1/2 min-w-36 text-2xl font-bold text-left rounded-lg bg-transparent border border-solid pl-1"
-            value={stats[ability]}
+            value={inputs[ability]}
             max={maxStat}
             min={minStat}
             onChange={handleStatChange(ability)}
-            />
+            onBlur={handleStatBlur(ability)}
+          />
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- adjust cost calculation and boundaries for ability score changes
- handle manual stat entry

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876c766e2cc83279c093d218fb75211